### PR TITLE
dockerize the flask server

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,3 +43,12 @@ cd government_up_yet
 export FLASK_APP=service.py
 flask run
 ```
+
+# Run with `docker-compose`
+
+Easily run the app locally. Currently only runs server. Not for production.
+
+```
+docker-compose up
+# Ctrl-C to tear down
+```

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,8 @@
+version: '3'
+
+services:
+  web:
+    build:
+      context: ./government_up_yet
+    ports:
+      - "5000:5000"

--- a/government_up_yet/Dockerfile
+++ b/government_up_yet/Dockerfile
@@ -1,0 +1,24 @@
+# base image
+FROM python:3.6.5-slim
+
+# install netcat
+RUN apt-get update && \
+    apt-get -y install netcat && \
+    apt-get clean
+
+# set working directory
+WORKDIR /usr/src/app
+
+# add and install requirements
+COPY ./requirements.txt /usr/src/app/requirements.txt
+RUN pip install -r requirements.txt
+
+# add entrypoint.sh
+COPY ./entrypoint.sh /usr/src/app/entrypoint.sh
+RUN chmod +x /usr/src/app/entrypoint.sh
+
+# add app
+COPY . /usr/src/app
+
+# run server
+CMD ["/usr/src/app/entrypoint.sh"]

--- a/government_up_yet/entrypoint.sh
+++ b/government_up_yet/entrypoint.sh
@@ -1,0 +1,3 @@
+#!/bin/bash
+export FLASK_APP=service.py
+flask run --host=0.0.0.0

--- a/government_up_yet/requirements.txt
+++ b/government_up_yet/requirements.txt
@@ -6,7 +6,6 @@ itsdangerous==1.1.0
 Jinja2==2.10
 MarkupSafe==1.1.0
 more-itertools==5.0.0
-pkg-resources==0.0.0
 pluggy==0.8.0
 py==1.7.0
 pytest==4.0.2


### PR DESCRIPTION
This PR adds a Dockerfile for the flask server and creates a convenient `docker-compose.yml` for running the server locally.

In the near future, docker-compose will also serve the frontend.