### PR TITLE
the issuer, the cert, and the changes to ingress for tls and https

### DIFF
--- a/k8s/certificate-prod.yml
+++ b/k8s/certificate-prod.yml
@@ -1,0 +1,21 @@
+---
+apiVersion: certmanager.k8s.io/v1alpha1
+kind: Certificate
+metadata:
+  name: government-up-yet
+spec:
+  secretName: government-up-yet-tls
+  issuerRef:
+    name: letsencrypt
+    kind: ClusterIssuer
+  commonName: www.isthegovernmentupyet.com
+  dnsNames:
+    - api.isthegovernmentupyet.com
+    - www.isthegovernmentupyet.com
+  acme:
+    config:
+      - http01:
+          ingress: app-ingress
+        domains:
+          - api.isthegovernmentupyet.com
+          - www.isthegovernmentupyet.com

--- a/k8s/certificate-staging.yml
+++ b/k8s/certificate-staging.yml
@@ -1,0 +1,21 @@
+---
+apiVersion: certmanager.k8s.io/v1alpha1
+kind: Certificate
+metadata:
+  name: government-up-yet-staging
+spec:
+  secretName: government-up-yet-staging-tls
+  issuerRef:
+    name: letsencrypt-staging
+    kind: ClusterIssuer
+  commonName: www.isthegovernmentupyet.com
+  dnsNames:
+    - api.isthegovernmentupyet.com
+    - www.isthegovernmentupyet.com
+  acme:
+    config:
+      - http01:
+          ingress: app-ingress
+        domains:
+          - api.isthegovernmentupyet.com
+          - www.isthegovernmentupyet.com

--- a/k8s/ingress.yml
+++ b/k8s/ingress.yml
@@ -10,16 +10,23 @@ metadata:
   annotations:
     kubernetes.io/ingress.class: nginx
     nginx.ingress.kubernetes.io/ssl-redirect: "false"
-    nginx.ingress.kubernetes.io/rewrite-target: /
+    certmanager.k8s.io/cluster-issuer: letsencrypt
 spec:
+  tls:
+    - hosts:
+      - api.isthegovernmentupyet.com
+      - www.isthegovernmentupyet.com
+      secretName: government-up-yet-tls
   rules:
-      - http:
+      - host: api.isthegovernmentupyet.com
+        http:
           paths:
-          - path: /api
+          - path: /
             backend:
               serviceName: backend
               servicePort: 80
-      - http:
+      - host: www.isthegovernmentupyet.com
+        http:
           paths:
           - path: /
             backend:

--- a/k8s/issuer-prod.yml
+++ b/k8s/issuer-prod.yml
@@ -1,0 +1,12 @@
+---
+apiVersion: certmanager.k8s.io/v1alpha1
+kind: ClusterIssuer
+metadata:
+  name: letsencrypt
+spec:
+  acme:
+    server: https://acme-v02.api.letsencrypt.org/directory
+    email: damon.shane.myers@gmail.com
+    privateKeySecretRef:
+      name: letsencrypt
+    http01: {}

--- a/k8s/issuer-staging.yml
+++ b/k8s/issuer-staging.yml
@@ -1,0 +1,12 @@
+---
+apiVersion: certmanager.k8s.io/v1alpha1
+kind: ClusterIssuer
+metadata:
+  name: letsencrypt-staging
+spec:
+  acme:
+    server: https://acme-staging-v02.api.letsencrypt.org/directory
+    email: damon.shane.myers@gmail.com
+    privateKeySecretRef:
+      name: letsencrypt-staging
+    http01: {}


### PR DESCRIPTION
This PR adds the kubernetes yamls required for setting up an issuer and certificate with cert-manager. The cert-manager coordinates with letsencrypt to get us up-to-date signed certificates for our https traffic.

Everything has been applied and does not need to be touched again. These yamls are here because they were applied to the cluster.

Checkout out the https awesome! 😍 🔒 
https://www.isthegovernmentupyet.com/
https://api.isthegovernmentupyet.com/